### PR TITLE
[UI] 메인 화면

### DIFF
--- a/Wemmy-iOS/Wemmy-iOS/Feature/Main/Community/CommunityView.swift
+++ b/Wemmy-iOS/Wemmy-iOS/Feature/Main/Community/CommunityView.swift
@@ -1,0 +1,18 @@
+//
+//  CommunityView.swift
+//  Wemmy-iOS
+//
+//  Created by 이예빈 on 5/22/24.
+//
+
+import SwiftUI
+
+struct CommunityView: View {
+    var body: some View {
+        Text("커뮤니티")
+    }
+}
+
+#Preview {
+    CommunityView()
+}

--- a/Wemmy-iOS/Wemmy-iOS/Feature/Main/Facility/FacilityView.swift
+++ b/Wemmy-iOS/Wemmy-iOS/Feature/Main/Facility/FacilityView.swift
@@ -1,0 +1,18 @@
+//
+//  FacilityView.swift
+//  Wemmy-iOS
+//
+//  Created by 이예빈 on 5/22/24.
+//
+
+import SwiftUI
+
+struct FacilityView: View {
+    var body: some View {
+        Text("복지시설")
+    }
+}
+
+#Preview {
+    FacilityView()
+}

--- a/Wemmy-iOS/Wemmy-iOS/Feature/Main/Home/HomeView.swift
+++ b/Wemmy-iOS/Wemmy-iOS/Feature/Main/Home/HomeView.swift
@@ -1,0 +1,18 @@
+//
+//  HomeView.swift
+//  Wemmy-iOS
+//
+//  Created by 이예빈 on 5/22/24.
+//
+
+import SwiftUI
+
+struct HomeView: View {
+    var body: some View {
+        Text("홈")
+    }
+}
+
+#Preview {
+    HomeView()
+}

--- a/Wemmy-iOS/Wemmy-iOS/Feature/Main/Mypage/MypageView.swift
+++ b/Wemmy-iOS/Wemmy-iOS/Feature/Main/Mypage/MypageView.swift
@@ -1,0 +1,18 @@
+//
+//  MypageView.swift
+//  Wemmy-iOS
+//
+//  Created by 이예빈 on 5/22/24.
+//
+
+import SwiftUI
+
+struct MypageView: View {
+    var body: some View {
+        Text("마이페이지")
+    }
+}
+
+#Preview {
+    MypageView()
+}

--- a/Wemmy-iOS/Wemmy-iOS/Feature/Main/TabBar/TabBarView.swift
+++ b/Wemmy-iOS/Wemmy-iOS/Feature/Main/TabBar/TabBarView.swift
@@ -1,0 +1,100 @@
+//
+//  TabView.swift
+//  Wemmy-iOS
+//
+//  Created by 이예빈 on 5/22/24.
+//
+
+import SwiftUI
+
+// MARK: - 탭 목록
+enum Tab: String {
+    
+    case Home, Facility, Community, Mypage
+}
+
+// MARK: - 탭바 ViewModel
+class TabBarViewModel: ObservableObject {
+    
+    @Published var selectedTab: Tab = .Home
+}
+
+// MARK: - 메인화면 탭 뷰
+struct TabBarView: View {
+    
+    @ObservedObject var viewModel: TabBarViewModel
+    
+    var body: some View {
+        NavigationStack {
+            TabView(selection: $viewModel.selectedTab) {
+                
+                // MARK: 혜택 정보 화면(홈 화면)
+                HomeView()
+                    .tabItem {
+                        Image(systemName: "heart.fill")
+                            .resizable()
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(Color.Gray400)
+                        
+                        Text("홈")
+                            .font(.Medium12)
+                            .foregroundColor(Color.Gray400)
+                    }
+                    .tag(Tab.Home)
+                
+                // MARK: 복지시설 화면
+                FacilityView()
+                    .tabItem {
+                        Image(systemName: "map")
+                            .resizable()
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(Color.Gray400)
+                            .environment(\.symbolVariants, .none)
+                        
+                        Text("복지시설")
+                            .font(.Medium12)
+                            .foregroundColor(Color.Gray400)
+                    }
+                    .tag(Tab.Facility)
+                
+                // MARK: 커뮤니티 화면
+                CommunityView()
+                    .tabItem {
+                        Image(systemName: "heart.text.square")
+                            .resizable()
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(Color.Gray400)
+                            .environment(\.symbolVariants, .none)
+                        
+                        Text("커뮤니티")
+                            .font(.Medium12)
+                            .foregroundColor(Color.Gray400)
+                    }
+                    .tag(Tab.Community)
+                
+                // MARK: 마이페이지 화면
+                MypageView()
+                    .tabItem {
+                        Image(systemName: "person")
+                            .resizable()
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(Color.Gray400)
+                            .environment(\.symbolVariants, .none)
+                        
+                        Text("MY")
+                            .font(.Medium12)
+                            .foregroundColor(Color.Gray400)
+                    }
+                    .tag(Tab.Mypage)
+            }
+            .accentColor(Color.Pink600)
+            .ignoresSafeArea(edges: .all)
+            
+            Spacer()
+        }
+    }
+}
+
+#Preview {
+    TabBarView(viewModel: TabBarViewModel())
+}

--- a/Wemmy-iOS/Wemmy-iOS/Feature/Main/TabBar/TabBarView.swift
+++ b/Wemmy-iOS/Wemmy-iOS/Feature/Main/TabBar/TabBarView.swift
@@ -1,5 +1,5 @@
 //
-//  TabView.swift
+//  TabBarView.swift
 //  Wemmy-iOS
 //
 //  Created by 이예빈 on 5/22/24.

--- a/Wemmy-iOS/Wemmy-iOS/Feature/Onboarding/OnboardingDistrictSelectionView.swift
+++ b/Wemmy-iOS/Wemmy-iOS/Feature/Onboarding/OnboardingDistrictSelectionView.swift
@@ -13,6 +13,8 @@ struct OnboardingDistrictSelectionView: View {
     
     @State private var selectedDistrict: String = "자치구"
     
+    @State private var isNavigationToHomeView: Bool = false
+    
     var body: some View {
         VStack(alignment: .leading) {
             DistrictSelectionProgressBarSection()
@@ -22,9 +24,12 @@ struct OnboardingDistrictSelectionView: View {
                 DistrictSelectionFormSection(selectedDistrict: $selectedDistrict)
                 Spacer()
                 CustomButton(title: "완료", action: {
-                    // 완료 버튼 액션
+                    self.isNavigationToHomeView.toggle()
                 }, isEnabled: selectedDistrict != "자치구")
                 .padding(.vertical, 20)
+                .fullScreenCover(isPresented: $isNavigationToHomeView){
+                    TabBarView(viewModel: TabBarViewModel())
+                }
             }
             .padding(.horizontal, 20)
         }


### PR DESCRIPTION
## 📍 _Issue_

- #11

## 🗝️ _Key Changes_

여기서 발생한 문제 하나가 아무리 SF Symbols에서 fill이 아닌 이미지를 가져오려고 해도 자꾸 fill이 default가 되어버려서 당황하던 중 `.environment(\.symbolVariants, .none)` 무적 코드를 발견했어요 ㅎㅎ.
그래서 선으로만 이루어진 아이콘들을 사용할 수 있게 되었습니다!

## 📱 _Simulation_

https://github.com/Team-Wemmy/Wemmy-iOS/assets/84004751/0393537d-7b6b-4e02-84f1-6dcccb12d73c

## 📁 _Reference_

https://stackoverflow.com/questions/69319575/how-to-change-filled-icon-to-not-filled-on-tabview-tabitem-in-ios-15-xcode-13

## 👥 _To Reviewers_
